### PR TITLE
Fix bug breaking SCI Rx/Tx with DMA/DTC, fix memory corruption in USB peripheral

### DIFF
--- a/source/r_sci_rx/r_sci_rx_vx.xx/r_sci_rx/src/r_sci_rx.c
+++ b/source/r_sci_rx/r_sci_rx_vx.xx/r_sci_rx/src/r_sci_rx.c
@@ -409,7 +409,8 @@ sci_err_t R_SCI_Open (uint8_t const      chan,
     {
 #if (TX_DTC_DMACA_ENABLE & 0x01 || TX_DTC_DMACA_ENABLE & 0x02)
         /* DTC/DMAC don't use the queue */
-        if ((SCI_DTC_ENABLE != g_handles[chan]->rom->dtc_dmaca_tx_enable) && (SCI_DMACA_ENABLE != g_handles[chan]->rom->dtc_dmaca_tx_enable))
+        if (((SCI_DTC_ENABLE != g_handles[chan]->rom->dtc_dmaca_tx_enable) && (SCI_DMACA_ENABLE != g_handles[chan]->rom->dtc_dmaca_tx_enable))
+        	|| ((SCI_DTC_ENABLE != g_handles[chan]->rom->dtc_dmaca_rx_enable) && (SCI_DMACA_ENABLE != g_handles[chan]->rom->dtc_dmaca_rx_enable)))
         {
             err = sci_init_queues(chan);
         }

--- a/source/r_usb_basic/r_usb_basic_vx.xx/r_usb_basic/src/driver/r_usb_pdriver.c
+++ b/source/r_usb_basic/r_usb_basic_vx.xx/r_usb_basic/src/driver/r_usb_pdriver.c
@@ -1181,7 +1181,7 @@ usb_er_t usb_pstd_transfer_start(usb_utr_t * ptr)
 
     rtos_get_fixed_memory(&g_rtos_usb_mpf_id, (void **)&p_tran_data, RTOS_ZERO);
 
-    if (NULL == ptr)
+    if (NULL == ptr || NULL == p_tran_data)
     {
         return USB_ERROR;
     }


### PR DESCRIPTION
Hello Renesas maintainers, I encountered these two bugs while using RxFIT modules:

1. If using SCI module with DMA/DTC only on Tx, Rx would not work, and vice versa.
2. If USB peripheral FreeRTOS fixed memory pool runs out of space, memory at address 0 is corrupted.